### PR TITLE
Fix YouTube embeds, drawing canvas, and HTTPS links

### DIFF
--- a/act.html
+++ b/act.html
@@ -464,7 +464,7 @@
                 </span>
                 <br /><br />
                 <a
-                  href="http://www.mittiprickteatern.se/"
+                  href="https://www.mittiprickteatern.se/djungelboken/"
                   target="_blank"
                   class="enter-btn"
                 >
@@ -505,7 +505,7 @@
                 </span>
                 <br /><br />
                 <a
-                  href="http://www.mittiprickteatern.se/arkiv/gumman-gra/"
+                  href="https://www.mittiprickteatern.se/arkiv/gumman-gra/"
                   target="_blank"
                   class="enter-btn"
                 >
@@ -591,10 +591,27 @@
             <font color="#FF0000" size="3"><b>*** HAUNTED WEBRING ***</b></font>
             <br /><br />
             <img src="https://i.gifer.com/VxN.gif" width="25" />
-            [ <a href="#">< Prev</a> | <a href="#">Summon Random</a> |
-            <a href="#">Next ></a> ]
+            [ <a href="#" onclick="goToRandomPage(); return false;">< Prev</a> | <a href="#" onclick="goToRandomPage(); return false;">Summon Random</a> |
+            <a href="#" onclick="goToRandomPage(); return false;">Next ></a> ]
             <img src="https://i.gifer.com/VxN.gif" width="25" />
           </div>
+          <script>
+            var sitePages = [
+              'index.html',
+              'about.html',
+              'Music/music.html',
+              'video/gallery.html',
+              'video/bike.html',
+              'draw/draw.html',
+              'web/web.html',
+              'ML/ML.html',
+              'wikiquest/index.html'
+            ];
+            function goToRandomPage() {
+              var randomIndex = Math.floor(Math.random() * sitePages.length);
+              window.location.href = sitePages[randomIndex];
+            }
+          </script>
         </td>
       </tr>
     </table>
@@ -610,30 +627,27 @@
       <img src="https://i.gifer.com/6lO6.gif" alt="Bat" width="40" />
       <img src="https://i.gifer.com/6lO6.gif" alt="Bat" width="40" />
       <br /><br />
-      <a href="#"
-        ><img
+      <img
           src="https://cyber.dabamos.de/88x31/ie5.gif"
           alt="Best viewed in IE"
           class="badge"
           width="88"
           height="31"
-      /></a>
-      <a href="#"
-        ><img
+      />
+      <img
           src="https://cyber.dabamos.de/88x31/notepad2.gif"
           alt="Made with Notepad"
           class="badge"
           width="88"
           height="31"
-      /></a>
-      <a href="#"
-        ><img
+      />
+      <img
           src="https://cyber.dabamos.de/88x31/netscape.gif"
           alt="Netscape Now"
           class="badge"
           width="88"
           height="31"
-      /></a>
+      />
       <br /><br />
       <font color="#4a0000" size="2">
         (c) 2003 ~*~ Last updated from beyond the grave ~*~<br />

--- a/draw/draw.html
+++ b/draw/draw.html
@@ -1,1 +1,15 @@
-<p>Drawing program</p>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Drawing program</title>
+    <style>
+        html, body { margin: 0; padding: 0; overflow: hidden; }
+        canvas { display: block; cursor: crosshair; }
+    </style>
+</head>
+<body>
+    <canvas></canvas>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/video/bike.html
+++ b/video/bike.html
@@ -47,17 +47,17 @@
     <div class="showcase-container">
         <div class="video-card">
             <div class="video-title">Storyboard</div>
-            <iframe width="320" height="180" src="https://youtu.be/9scQYSF13AY" 
+            <iframe width="320" height="180" src="https://www.youtube.com/embed/9scQYSF13AY"
                 title="Storyboard" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
         </div>
         <div class="video-card">
             <div class="video-title">Black and White</div>
-            <iframe width="320" height="180" src="https://youtu.be/FT3VMcTd0Ck" 
+            <iframe width="320" height="180" src="https://www.youtube.com/embed/FT3VMcTd0Ck"
                 title="Black and White" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
         </div>
         <div class="video-card">
             <div class="video-title">''''Final'''' version (hopefully we'll redo this, not happy tbh)</div>
-            <iframe width="320" height="180" src="https://youtu.be/CvW_bPZ44jY" 
+            <iframe width="320" height="180" src="https://www.youtube.com/embed/CvW_bPZ44jY"
                 title="Final (not done)" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- **#8** `video/bike.html` — YouTube iframes were using `youtu.be/<id>` (which doesn't render in iframes); switched all three to `youtube.com/embed/<id>`.
- **#9** `draw/draw.html` — was a one-line placeholder loading `main.js`, which crashed trying to grab a missing `<canvas>`. Added a fullscreen `<canvas>` and the script tag so the existing paint app actually runs.
- **#10** `act.html` — upgraded both Mittiprickteatern links to HTTPS, and pointed the Jungle Book link at the new `/djungelboken/` URL (the old root path was stale).
- Bonus polish on `act.html`: wired the haunted webring's Prev/Random/Next anchors to a `goToRandomPage()` picker over a sitePages array (they were dead `#` anchors), and stripped dummy `<a href="#">` wrappers from the three 88x31 badges.

Closes #8
Closes #9
Closes #10

## Test plan
- [ ] Load `video/bike.html` and confirm all three YouTube videos render and play
- [ ] Load `draw/draw.html` and confirm the color palette renders + drawing works (mouse drag, color keys R/G/B/Y/S/E/W/X, size keys 1/2/3)
- [ ] Click both Mittiprickteatern links on `act.html` — Jungle Book should land on `/djungelboken/`, Gumman Grå on `/arkiv/gumman-gra/`, both over HTTPS with no mixed-content warnings
- [ ] Click webring Prev/Random/Next on `act.html` and confirm it navigates to a random site page